### PR TITLE
Reduce string allocations in MdnsServer hot path

### DIFF
--- a/bench/Benchmarks.CCSWE.nanoFramework/Benchmarks.CCSWE.nanoFramework.nfproj
+++ b/bench/Benchmarks.CCSWE.nanoFramework/Benchmarks.CCSWE.nanoFramework.nfproj
@@ -26,25 +26,25 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="mscorlib">
+    <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Benchmark">
+    <Reference Include="nanoFramework.Benchmark, Version=1.0.113.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Benchmark.1.0.113\lib\nanoFramework.Benchmark.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Logging">
+    <Reference Include="nanoFramework.Logging, Version=1.1.161.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.161\lib\nanoFramework.Logging.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Runtime.Native">
+    <Reference Include="nanoFramework.Runtime.Native, Version=1.7.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.7.11\lib\nanoFramework.Runtime.Native.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Collections">
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.67\lib\nanoFramework.System.Collections.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.System.Text">
+    <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>
     </Reference>
-    <Reference Include="System.Diagnostics.Stopwatch">
+    <Reference Include="System.Diagnostics.Stopwatch, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Diagnostics.Stopwatch.1.2.862\lib\System.Diagnostics.Stopwatch.dll</HintPath>
     </Reference>
   </ItemGroup>

--- a/samples/Samples.CCSWE.nanoFramework.Networking/Samples.CCSWE.nanoFramework.Networking.nfproj
+++ b/samples/Samples.CCSWE.nanoFramework.Networking/Samples.CCSWE.nanoFramework.Networking.nfproj
@@ -38,14 +38,26 @@
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
+    <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="nanoFramework.Hosting, Version=2.0.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Hosting.2.0.11\lib\nanoFramework.Hosting.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.Logging, Version=1.1.161.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Logging.1.1.161\lib\nanoFramework.Logging.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Events, Version=1.11.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Events.1.11.32\lib\nanoFramework.Runtime.Events.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Runtime.Native, Version=1.7.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Runtime.Native.1.7.11\lib\nanoFramework.Runtime.Native.dll</HintPath>
+    </Reference>
+    <Reference Include="nanoFramework.System.Collections, Version=1.5.67.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.System.Collections.1.5.67\lib\nanoFramework.System.Collections.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="nanoFramework.System.Text, Version=1.3.42.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Text.1.3.42\lib\nanoFramework.System.Text.dll</HintPath>

--- a/samples/Samples.CCSWE.nanoFramework.Networking/packages.config
+++ b/samples/Samples.CCSWE.nanoFramework.Networking/packages.config
@@ -1,9 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hosting" version="2.0.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.System.Collections" version="1.5.67" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Device.Wifi" version="1.5.141" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.IO.Streams" version="1.1.96" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Net" version="1.11.50" targetFramework="netnano1.0" />

--- a/samples/Samples.CCSWE.nanoFramework.Networking/packages.lock.json
+++ b/samples/Samples.CCSWE.nanoFramework.Networking/packages.lock.json
@@ -8,11 +8,23 @@
         "resolved": "1.17.11",
         "contentHash": "HezzAc0o2XrSGf85xSeD/6xsO6ohF9hX6/iMQ1IZS6Zw6umr4WfAN2Jv0BrPxkaYwzEegJxxZujkHoUIAqtOMw=="
       },
+      "nanoFramework.DependencyInjection": {
+        "type": "Direct",
+        "requested": "[1.1.32, 1.1.32]",
+        "resolved": "1.1.32",
+        "contentHash": "jlkGPDppz73ThMFUwj9+bwUFYEM+1ZHf9SzLfj9k64ToMA5k/3l/HWtgBhiZcGcd/Y7H7Q9ISbADEKQ7PMELpg=="
+      },
       "nanoFramework.Hosting": {
         "type": "Direct",
         "requested": "[2.0.11, 2.0.11]",
         "resolved": "2.0.11",
         "contentHash": "gs6c2fVEnAy5vskaZG2ZUIeGnxPX58W28+jBCC6aSKfEEwg3Jg4PIFdgFpRnemiqTpllqGZ5jPyBP0oyhg5Zfw=="
+      },
+      "nanoFramework.Logging": {
+        "type": "Direct",
+        "requested": "[1.1.161, 1.1.161]",
+        "resolved": "1.1.161",
+        "contentHash": "ASEnCqp/WL+0EPyTYAUUdBSX6g1GkqewPOrTCLq9iZicf9+DFDzd+fpzrfinWd3YqSQ+eb16QzReARm1V0EfNw=="
       },
       "nanoFramework.Runtime.Events": {
         "type": "Direct",
@@ -25,6 +37,12 @@
         "requested": "[1.7.11, 1.7.11]",
         "resolved": "1.7.11",
         "contentHash": "XPSTltZ9KeBruogVmjQpCphi1nLoJH49mpyp2eGBs8BTjKuL5TkMO20MoI8r73F/PW5AppTq49HvIZZavU5nPQ=="
+      },
+      "nanoFramework.System.Collections": {
+        "type": "Direct",
+        "requested": "[1.5.67, 1.5.67]",
+        "resolved": "1.5.67",
+        "contentHash": "MjSipUB70vrxjqTm1KfKTUqqjd0wbweiNyYFXONi0XClrH6HXsuX2lhDqXM8NWuYnWyYOqx8y20sXbvsH+4brg=="
       },
       "nanoFramework.System.Device.Wifi": {
         "type": "Direct",

--- a/src/CCSWE.nanoFramework.Collections.Concurrent/CCSWE.nanoFramework.Collections.Concurrent.nuspec
+++ b/src/CCSWE.nanoFramework.Collections.Concurrent/CCSWE.nanoFramework.Collections.Concurrent.nuspec
@@ -17,10 +17,12 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe collections concurrent thread</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Configuration/CCSWE.nanoFramework.Configuration.nuspec
+++ b/src/CCSWE.nanoFramework.Configuration/CCSWE.nanoFramework.Configuration.nuspec
@@ -17,21 +17,23 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe configuration</tags>
     <dependencies>
-      <!--
-	  <dependency id="CCSWE.nanoFramework.Collections.Concurrent" version="$version$" />
-      <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
-	  -->
-      <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.Json" version="2.2.203" />
-      <dependency id="nanoFramework.Logging" version="1.1.161" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.87" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <!--
+        <dependency id="CCSWE.nanoFramework.Collections.Concurrent" version="$version$" />
+        <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
+        -->
+        <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+        <dependency id="nanoFramework.Json" version="2.2.203" />
+        <dependency id="nanoFramework.Logging" version="1.1.161" />
+        <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.87" />
+        <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+        <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Core/CCSWE.nanoFramework.Core.nuspec
+++ b/src/CCSWE.nanoFramework.Core/CCSWE.nanoFramework.Core.nuspec
@@ -17,8 +17,10 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe core</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.DhcpServer/CCSWE.nanoFramework.DhcpServer.nuspec
+++ b/src/CCSWE.nanoFramework.DhcpServer/CCSWE.nanoFramework.DhcpServer.nuspec
@@ -17,14 +17,16 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe dhcp server</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.Logging" version="1.1.161" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
-      <dependency id="nanoFramework.System.Net" version="1.11.50" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.Logging" version="1.1.161" />
+        <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
+        <dependency id="nanoFramework.System.Net" version="1.11.50" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+        <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.FileStorage/CCSWE.nanoFramework.FileStorage.nuspec
+++ b/src/CCSWE.nanoFramework.FileStorage/CCSWE.nanoFramework.FileStorage.nuspec
@@ -17,12 +17,14 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe file io</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
-      <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.87" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+        <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+        <dependency id="nanoFramework.System.IO.FileSystem" version="1.1.87" />
+        <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Graphics/CCSWE.nanoFramework.Graphics.nuspec
+++ b/src/CCSWE.nanoFramework.Graphics/CCSWE.nanoFramework.Graphics.nuspec
@@ -17,10 +17,12 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe graphics color</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Math" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.Graphics.Core" version="1.2.45" />
-      <dependency id="nanoFramework.System.Math" version="1.5.116" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="CCSWE.nanoFramework.Math" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.Graphics.Core" version="1.2.45" />
+        <dependency id="nanoFramework.System.Math" version="1.5.116" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Hosting/CCSWE.nanoFramework.Hosting.nuspec
+++ b/src/CCSWE.nanoFramework.Hosting/CCSWE.nanoFramework.Hosting.nuspec
@@ -17,15 +17,17 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe hosting</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
-      <dependency id="CCSWE.nanoFramework.Logging" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.Hosting" version="2.0.11" />
-      <dependency id="nanoFramework.Logging" version="1.1.161" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
+        <dependency id="CCSWE.nanoFramework.Logging" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+        <dependency id="nanoFramework.Hosting" version="2.0.11" />
+        <dependency id="nanoFramework.Logging" version="1.1.161" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+        <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Logging/CCSWE.nanoFramework.Logging.nuspec
+++ b/src/CCSWE.nanoFramework.Logging/CCSWE.nanoFramework.Logging.nuspec
@@ -17,10 +17,12 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe logging</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.Logging" version="1.1.161" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+        <dependency id="nanoFramework.Logging" version="1.1.161" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Math/CCSWE.nanoFramework.Math.nuspec
+++ b/src/CCSWE.nanoFramework.Math/CCSWE.nanoFramework.Math.nuspec
@@ -17,8 +17,10 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe math fast</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.System.Math" version="1.5.116" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.System.Math" version="1.5.116" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nuspec
+++ b/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nuspec
@@ -17,19 +17,21 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe mdns multicast dns server</tags>
     <dependencies>
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.Iot.Device.MulticastDns" version="1.0.260" />
-      <dependency id="nanoFramework.Logging" version="1.1.161" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
-      <dependency id="nanoFramework.System.Buffers.Binary.BinaryPrimitives" version="1.2.862" />
-      <dependency id="nanoFramework.System.Buffers.Helpers" version="1.0.201" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
-      <dependency id="nanoFramework.System.Net" version="1.11.50" />
-      <dependency id="nanoFramework.System.Net.Sockets.UdpClient" version="1.1.101" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+        <dependency id="nanoFramework.Iot.Device.MulticastDns" version="1.0.260" />
+        <dependency id="nanoFramework.Logging" version="1.1.161" />
+        <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+        <dependency id="nanoFramework.System.Buffers.Binary.BinaryPrimitives" version="1.2.862" />
+        <dependency id="nanoFramework.System.Buffers.Helpers" version="1.0.201" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
+        <dependency id="nanoFramework.System.Net" version="1.11.50" />
+        <dependency id="nanoFramework.System.Net.Sockets.UdpClient" version="1.1.101" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+        <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.MdnsServer/Internal/MdnsResponse.cs
+++ b/src/CCSWE.nanoFramework.MdnsServer/Internal/MdnsResponse.cs
@@ -7,4 +7,8 @@ namespace CCSWE.nanoFramework.MdnsServer.Internal;
 /// </summary>
 internal sealed class MdnsResponse : Response
 {
+    public bool IsEmpty()
+    {
+        return _answers.Count == 0 && _additionals.Count == 0 && _servers.Count == 0;
+    }
 }

--- a/src/CCSWE.nanoFramework.MdnsServer/MdnsServer.cs
+++ b/src/CCSWE.nanoFramework.MdnsServer/MdnsServer.cs
@@ -20,6 +20,8 @@ public sealed class MdnsServer : IMdnsServer, IDisposable
 
     private readonly int _defaultTtl;
     private bool _disposed;
+    private string? _fullyQualifiedHostname;
+    private string? _fullyQualifiedHostnameLower;
     private string? _hostname;
     private IPAddress? _ipAddress;
     private readonly object _lock = new();
@@ -39,9 +41,11 @@ public sealed class MdnsServer : IMdnsServer, IDisposable
         ArgumentNullException.ThrowIfNull(options);
 
         _defaultTtl = options.DefaultTtl;
-        _hostname = options.Hostname;
         _logger = logger;
 
+        SetHostname(options.Hostname, false);
+        SetIPAddress(options.IPAddress, false);
+        
         foreach (MdnsServiceRegistration registration in options.Services)
         {
             AddService(registration);
@@ -59,31 +63,30 @@ public sealed class MdnsServer : IMdnsServer, IDisposable
     /// <inheritdoc />
     public string Hostname
     {
-        get => _hostname ?? throw new InvalidOperationException("Hostname has not been set");
-        set
-        {
-            lock (_lock)
-            {
-                _hostname = value;
-            }
-        }
+        get => CheckHostname(_hostname);
+        set => SetHostname(value, true);
     }
 
     /// <inheritdoc />
     public IPAddress IPAddress
     {
-        get => _ipAddress ?? throw new InvalidOperationException("IPAddress has not been set");
-        set
-        {
-            lock (_lock)
-            {
-                _ipAddress = value;
-            }
-        }
+        get => CheckIPAddress();
+        set => SetIPAddress(value, true);
     }
 
     /// <inheritdoc />
     public bool IsRunning => _started;
+
+    /// <inheritdoc />
+    public void AddService(MdnsServiceRegistration registration)
+    {
+        ArgumentNullException.ThrowIfNull(registration);
+
+        lock (_lock)
+        {
+            _services.Add(registration);
+        }
+    }
 
     /// <inheritdoc />
     public void Announce()
@@ -99,17 +102,16 @@ public sealed class MdnsServer : IMdnsServer, IDisposable
         }
     }
 
-    /// <inheritdoc />
-    public void AddService(MdnsServiceRegistration registration)
+    private static string CheckHostname(string? value)
     {
-        ArgumentNullException.ThrowIfNull(registration);
-
-        lock (_lock)
-        {
-            _services.Add(registration);
-        }
+        return string.IsNullOrEmpty(value) ? throw new InvalidOperationException("Hostname has not been set.") : value;
     }
 
+    private IPAddress CheckIPAddress()
+    {
+        return _ipAddress ?? throw new InvalidOperationException("IPAddress has not been set.");
+    }
+    
     /// <inheritdoc />
     public void Dispose()
     {
@@ -128,74 +130,6 @@ public sealed class MdnsServer : IMdnsServer, IDisposable
             Dispose(true);
             GC.SuppressFinalize(this);
         }
-    }
-
-    /// <inheritdoc />
-    public bool Start()
-    {
-        if (_started)
-        {
-            return true;
-        }
-        
-        lock (_lock)
-        {
-            if (_started)
-            {
-                return true;
-            }
-
-            _started = true;
-
-            try
-            {
-                ArgumentException.ThrowIfNullOrEmpty(_hostname);
-                ArgumentNullException.ThrowIfNull(_ipAddress);
-
-                _multicastDnsService = new MulticastDnsService();
-                _multicastDnsService.MessageReceived += HandleMessageReceived;
-                _multicastDnsService.Start();
-                
-                SendAnnouncement();
-
-                Log(LogLevel.Information, "Started");
-
-                return true;
-            }
-            catch (Exception ex)
-            {
-                Log(LogLevel.Error, $"Failed to start MDNS service. Message: {ex.Message}", ex);
-                Stop();
-            }
-        }
-
-        return false;
-    }
-
-    /// <inheritdoc />
-    public void Stop()
-    {
-        lock (_lock)
-        {
-            if (_multicastDnsService is not null)
-            {
-                try
-                {
-                    _multicastDnsService.MessageReceived -= HandleMessageReceived;
-                    _multicastDnsService.Stop();
-                    _multicastDnsService.Dispose();
-                    _multicastDnsService = null;
-                }
-                catch (Exception e)
-                {
-                    Log(LogLevel.Error, $"Error stopping mDNS service: {e.Message}", e);
-                }
-            }
-
-            _started = false;
-        }
-
-        Log(LogLevel.Information, "Stopped");
     }
 
     private void Dispose(bool disposing)
@@ -225,139 +159,128 @@ public sealed class MdnsServer : IMdnsServer, IDisposable
             return;
         }
 
+        string fullyQualifiedHostname;
+        string fullyQualifiedHostnameLower;
         string hostname;
         IPAddress ipAddress;
         MdnsServiceRegistration[] services;
 
         lock (_lock)
         {
+            fullyQualifiedHostname = CheckHostname(_fullyQualifiedHostname);
+            fullyQualifiedHostnameLower = CheckHostname(_fullyQualifiedHostnameLower);
             hostname = Hostname;
             ipAddress = IPAddress;
             services = (MdnsServiceRegistration[])_services.ToArray(typeof(MdnsServiceRegistration));
         }
 
-        var hostDomain = $"{hostname}.local";
-        var hostDomainLower = hostDomain.ToLower();
-        
-        var response = new MdnsResponse();
-        var shouldRespond = false;
+        var fullyQualifiedInstanceNames = new string[services.Length];
+        var fullyQualifiedInstanceNameLowers = new string[services.Length];
+        for (var i = 0; i < services.Length; i++)
+        {
+            fullyQualifiedInstanceNames[i] = services[i].GetFullyQualifiedInstanceName(hostname);
+            fullyQualifiedInstanceNameLowers[i] = fullyQualifiedInstanceNames[i].ToLower();
+        }
 
+        var response = new MdnsResponse();
+        
         foreach (var question in e.Message.GetQuestions())
         {
-            var answered = false;
-            
+            var domain = question.Domain;
+            var domainLower = domain?.ToLower();
             var queryType = question.QueryType;
-            var questionDomain = question.Domain;
-            var questionDomainLower = questionDomain?.ToLower();
 
             if (queryType is DnsResourceType.A or DnsResourceType.ANY)
             {
-                if (hostDomainLower.Equals(questionDomainLower))
+                if (fullyQualifiedHostnameLower.Equals(domainLower))
                 {
-                    answered = true;
-                    shouldRespond = true;
-                    
-                    response.AddAnswer(new ARecord(questionDomain, ipAddress, _defaultTtl));
+                    response.AddAnswer(new ARecord(domain, ipAddress, _defaultTtl));
                 }
             }
 
             if (queryType is DnsResourceType.PTR or DnsResourceType.ANY)
             {
-                if (ServiceEnumerationDomain.Equals(questionDomainLower))
+                if (ServiceEnumerationDomain.Equals(domainLower))
                 {
                     var addedTypes = new ArrayList();
                     
                     foreach (var registration in services)
                     {
-                        var serviceType = registration.ServiceType;
-                        var serviceTypeLower = serviceType.ToLower();
-                        
+                        var serviceTypeLower = registration.ServiceTypeLower;
+
                         if (addedTypes.Contains(serviceTypeLower))
                         {
                             continue;
                         }
-                        
-                        answered = true;
-                        shouldRespond = true;
-                        
+
                         addedTypes.Add(serviceTypeLower);
-                        response.AddAnswer(new PtrRecord(questionDomain, serviceType, GetTtl(registration)));
+                        response.AddAnswer(new PtrRecord(domain, registration.ServiceType, GetTtl(registration)));
                     }
                 }
                 else
                 {
-                    foreach (var registration in services)
+                    for (var i = 0; i < services.Length; i++)
                     {
-                        var serviceType = registration.ServiceType;
-                        var serviceTypeLower = serviceType.ToLower();
-                        
-                        if (!serviceTypeLower.Equals(questionDomainLower))
+                        var registration = services[i];
+
+                        if (!registration.ServiceTypeLower.Equals(domainLower))
                         {
                             continue;
                         }
-                        
-                        answered = true;
-                        shouldRespond = true;
-                        
-                        var fullyQualifiedInstance = registration.GetFullyQualifiedInstance(hostname);
 
-                        response.AddAnswer(new PtrRecord(questionDomain, fullyQualifiedInstance, GetTtl(registration)));
-                        response.AddAdditional(new SrvRecord(fullyQualifiedInstance, registration.Priority, registration.Weight, registration.Port, hostDomain, GetTtl(registration)));
+                        var fullyQualifiedInstance = fullyQualifiedInstanceNames[i];
+
+                        response.AddAnswer(new PtrRecord(domain, fullyQualifiedInstance, GetTtl(registration)));
+                        response.AddAdditional(new SrvRecord(fullyQualifiedInstance, registration.Priority, registration.Weight, registration.Port, fullyQualifiedHostname, GetTtl(registration)));
 
                         if (!string.IsNullOrEmpty(registration.Txt))
                         {
                             response.AddAdditional(new TxtRecord(fullyQualifiedInstance, registration.Txt, GetTtl(registration)));
                         }
 
-                        response.AddAdditional(new ARecord(hostDomain, ipAddress, GetTtl(registration)));
+                        response.AddAdditional(new ARecord(fullyQualifiedHostname, ipAddress, GetTtl(registration)));
                     }
                 }
             }
 
             if (queryType is DnsResourceType.SRV or DnsResourceType.ANY)
             {
-                foreach (var registration in services)
+                for (var i = 0; i < services.Length; i++)
                 {
-                    var fullyQualifiedInstanceLower = registration.GetFullyQualifiedInstance(hostname).ToLower();
-                    if (!fullyQualifiedInstanceLower.Equals(questionDomainLower))
+                    if (!fullyQualifiedInstanceNameLowers[i].Equals(domainLower))
                     {
                         continue;
                     }
 
-                    answered = true;
-                    shouldRespond = true;
+                    var registration = services[i];
 
-                    response.AddAnswer(new SrvRecord(questionDomain, registration.Priority, registration.Weight, registration.Port, hostDomain, GetTtl(registration)));
-                    response.AddAdditional(new ARecord(hostDomain, ipAddress, GetTtl(registration)));
+                    response.AddAnswer(new SrvRecord(domain, registration.Priority, registration.Weight, registration.Port, fullyQualifiedHostname, GetTtl(registration)));
+                    response.AddAdditional(new ARecord(fullyQualifiedHostname, ipAddress, GetTtl(registration)));
                 }
             }
 
             if (queryType is DnsResourceType.TXT or DnsResourceType.ANY)
             {
-                foreach (var registration in services)
+                for (var i = 0; i < services.Length; i++)
                 {
+                    var registration = services[i];
+
                     if (string.IsNullOrEmpty(registration.Txt))
                     {
                         continue;
                     }
 
-                    var fullyQualifiedInstanceLower = registration.GetFullyQualifiedInstance(hostname).ToLower();
-                    if (!fullyQualifiedInstanceLower.Equals(questionDomainLower))
+                    if (!fullyQualifiedInstanceNameLowers[i].Equals(domainLower))
                     {
                         continue;
                     }
 
-                    answered = true;
-                    shouldRespond = true;
-                    
-                    response.AddAnswer(new TxtRecord(questionDomain, registration.Txt, GetTtl(registration)));
+                    response.AddAnswer(new TxtRecord(domain, registration.Txt, GetTtl(registration)));
                 }
             }
-
-            Log(LogLevel.Trace, $"Question: [{QueryTypeToString(queryType)}] {questionDomain}{(answered ? " - ANSWERED" : "")}");
         }
 
-        e.Response = shouldRespond ? response : null;
+        e.Response = !response.IsEmpty() ? response : null;
     }
 
     private void Log(LogLevel logLevel, string message, Exception? exception = null)
@@ -400,42 +323,132 @@ public sealed class MdnsServer : IMdnsServer, IDisposable
 
     private void SendAnnouncement()
     {
-        var services = (MdnsServiceRegistration[])_services.ToArray(typeof(MdnsServiceRegistration));
-
-        if (services.Length == 0)
+        if (_services.Count == 0)
         {
             return;
         }
 
+        var services = (MdnsServiceRegistration[])_services.ToArray(typeof(MdnsServiceRegistration));
+
+        var fullyQualifiedHostname = CheckHostname(_fullyQualifiedHostname);
         var hostname = Hostname;
         var ipAddress = IPAddress;
 
-        var hostDomain = $"{hostname}.local";
-
         var announcement = new MdnsResponse();
-        var hostAnnounced = false;
+
+        announcement.AddAnswer(new ARecord(fullyQualifiedHostname, ipAddress, _defaultTtl));
 
         foreach (var registration in services)
         {
-            var fullyQualifiedInstance = registration.GetFullyQualifiedInstance(hostname);
+            var fullyQualifiedInstance = registration.GetFullyQualifiedInstanceName(hostname);
 
             announcement.AddAnswer(new PtrRecord(registration.ServiceType, fullyQualifiedInstance, GetTtl(registration)));
-            announcement.AddAnswer(new SrvRecord(fullyQualifiedInstance, registration.Priority, registration.Weight, registration.Port, hostDomain, GetTtl(registration)));
+            announcement.AddAnswer(new SrvRecord(fullyQualifiedInstance, registration.Priority, registration.Weight, registration.Port, fullyQualifiedHostname, GetTtl(registration)));
 
             if (!string.IsNullOrEmpty(registration.Txt))
             {
                 announcement.AddAnswer(new TxtRecord(fullyQualifiedInstance, registration.Txt, GetTtl(registration)));
             }
+        }
 
-            if (!hostAnnounced)
+        _multicastDnsService?.Send(announcement);
+
+        Log(LogLevel.Information, "Announced");
+    }
+
+    private void SetHostname(string? value, bool required)
+    {
+        if (required && string.IsNullOrEmpty(value))
+        {
+            throw new InvalidOperationException("Hostname cannot be null or empty.");
+        }
+        
+        lock (_lock)
+        {
+            _hostname = value;
+            _fullyQualifiedHostname = value is not null ? $"{value}.local" : null;
+            _fullyQualifiedHostnameLower = value is not null ? $"{value.ToLower()}.local" : null;
+        }
+    }
+
+    private void SetIPAddress(IPAddress? value, bool required)
+    {
+        if (required && value is null)
+        {
+            throw new InvalidOperationException("IPAddress cannot be null.");
+        }
+
+        lock (_lock)
+        {
+            _ipAddress = value;
+        }
+    }
+
+    /// <inheritdoc />
+    public bool Start()
+    {
+        if (_started)
+        {
+            return true;
+        }
+
+        lock (_lock)
+        {
+            if (_started)
             {
-                announcement.AddAnswer(new ARecord(hostDomain, ipAddress, _defaultTtl));
-                hostAnnounced = true;
+                return true;
+            }
+
+            _started = true;
+
+            try
+            {
+                CheckHostname(_hostname);
+                CheckIPAddress();
+                
+                _multicastDnsService = new MulticastDnsService();
+                _multicastDnsService.MessageReceived += HandleMessageReceived;
+                _multicastDnsService.Start();
+
+                SendAnnouncement();
+
+                Log(LogLevel.Information, "Started");
+
+                return true;
+            }
+            catch (Exception ex)
+            {
+                Log(LogLevel.Error, $"Failed to start MDNS service. Message: {ex.Message}", ex);
+                Stop();
             }
         }
 
-        _multicastDnsService!.Send(announcement);
-        
-        Log(LogLevel.Information, "Announced");
+        return false;
+    }
+
+    /// <inheritdoc />
+    public void Stop()
+    {
+        lock (_lock)
+        {
+            if (_multicastDnsService is not null)
+            {
+                try
+                {
+                    _multicastDnsService.MessageReceived -= HandleMessageReceived;
+                    _multicastDnsService.Stop();
+                    _multicastDnsService.Dispose();
+                    _multicastDnsService = null;
+                }
+                catch (Exception e)
+                {
+                    Log(LogLevel.Error, $"Error stopping mDNS service: {e.Message}", e);
+                }
+            }
+
+            _started = false;
+        }
+
+        Log(LogLevel.Information, "Stopped");
     }
 }

--- a/src/CCSWE.nanoFramework.MdnsServer/MdnsServerOptions.cs
+++ b/src/CCSWE.nanoFramework.MdnsServer/MdnsServerOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections;
+using System.Net;
 
 namespace CCSWE.nanoFramework.MdnsServer;
 
@@ -21,6 +22,14 @@ public class MdnsServerOptions
     /// </summary>
     public string? Hostname { get; set; }
 
+    /// <summary>
+    /// Gets or sets the IP address to be used by the <see cref="MdnsServer"/>.
+    /// </summary>
+    /// <value>
+    /// The IP address to bind the <see cref="MdnsServer"/> to, or <see langword="null"/> if not specified.
+    /// </value>
+    public IPAddress? IPAddress { get; set; }
+    
     /// <summary>Gets the service registrations to apply when <see cref="MdnsServer"/> is constructed.</summary>
     internal ArrayList Services => _services;
 

--- a/src/CCSWE.nanoFramework.MdnsServer/MdnsServiceRegistration.cs
+++ b/src/CCSWE.nanoFramework.MdnsServer/MdnsServiceRegistration.cs
@@ -36,6 +36,7 @@ public class MdnsServiceRegistration
 
         InstanceName = instanceName;
         ServiceType = serviceType;
+        ServiceTypeLower = serviceType.ToLower();
         Port = port;
         Txt = txt;
     }
@@ -61,6 +62,11 @@ public class MdnsServiceRegistration
     public string ServiceType { get; }
 
     /// <summary>
+    /// Gets the service type in lowercase (e.g., "_http._tcp.local").
+    /// </summary>
+    internal string ServiceTypeLower { get; }
+
+    /// <summary>
     /// Gets or sets the TTL override in seconds. If <c>0</c>, uses <see cref="MdnsServerOptions.DefaultTtl"/>.
     /// </summary>
     public int Ttl { get; set; }
@@ -81,5 +87,5 @@ public class MdnsServiceRegistration
     /// </summary>
     /// <param name="hostname">The hostname to use as the instance name when <see cref="InstanceName"/> is <see langword="null"/>.</param>
     /// <returns>The fully qualified service instance name.</returns>
-    public string GetFullyQualifiedInstance(string hostname) => $"{InstanceName ?? hostname}.{ServiceType}";
+    internal string GetFullyQualifiedInstanceName(string hostname) => $"{InstanceName ?? hostname}.{ServiceType}";
 }

--- a/src/CCSWE.nanoFramework.Mediator/CCSWE.nanoFramework.Mediator.nuspec
+++ b/src/CCSWE.nanoFramework.Mediator/CCSWE.nanoFramework.Mediator.nuspec
@@ -17,17 +17,19 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe mediator</tags>
     <dependencies>
-      <!--
-	  <dependency id="CCSWE.nanoFramework.Collections.Concurrent" version="$version$" />
-	  -->
-      <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
-      <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.Logging" version="1.1.161" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <!--
+        <dependency id="CCSWE.nanoFramework.Collections.Concurrent" version="$version$" />
+        -->
+        <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
+        <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+        <dependency id="nanoFramework.Logging" version="1.1.161" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+        <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.NeoPixel/CCSWE.nanoFramework.NeoPixel.nuspec
+++ b/src/CCSWE.nanoFramework.NeoPixel/CCSWE.nanoFramework.NeoPixel.nuspec
@@ -17,13 +17,15 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe neopixel ws2812c</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Graphics" version="$version$" />
-      <dependency id="CCSWE.nanoFramework.Math" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.Graphics.Core" version="1.2.45" />
-      <dependency id="nanoFramework.Hardware.Esp32.Rmt" version="2.0.35" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
-      <dependency id="nanoFramework.System.Math" version="1.5.116" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="CCSWE.nanoFramework.Graphics" version="$version$" />
+        <dependency id="CCSWE.nanoFramework.Math" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.Graphics.Core" version="1.2.45" />
+        <dependency id="nanoFramework.Hardware.Esp32.Rmt" version="2.0.35" />
+        <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+        <dependency id="nanoFramework.System.Math" version="1.5.116" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Threading.TestFramework/CCSWE.nanoFramework.Threading.TestFramework.nfproj
+++ b/src/CCSWE.nanoFramework.Threading.TestFramework/CCSWE.nanoFramework.Threading.TestFramework.nfproj
@@ -18,7 +18,6 @@
     <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <Nullable>Enable</Nullable>
     <DocumentationFile>bin\$(Configuration)\CCSWE.nanoFramework.Threading.TestFramework.xml</DocumentationFile>
-    <TargetFrameworkVersion>v1.0</TargetFrameworkVersion>
     <RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
     <LangVersion>default</LangVersion>
   </PropertyGroup>

--- a/src/CCSWE.nanoFramework.Threading.TestFramework/CCSWE.nanoFramework.Threading.TestFramework.nuspec
+++ b/src/CCSWE.nanoFramework.Threading.TestFramework/CCSWE.nanoFramework.Threading.TestFramework.nuspec
@@ -17,8 +17,10 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe threading asynchronous</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.Threading/CCSWE.nanoFramework.Threading.nuspec
+++ b/src/CCSWE.nanoFramework.Threading/CCSWE.nanoFramework.Threading.nuspec
@@ -17,12 +17,14 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe threading asynchronous</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Collections.Concurrent" version="$version$" />
-      <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="CCSWE.nanoFramework.Collections.Concurrent" version="$version$" />
+        <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+        <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      </group>
     </dependencies>
   </metadata>
   <files>

--- a/src/CCSWE.nanoFramework.WebServer/CCSWE.nanoFramework.WebServer.nuspec
+++ b/src/CCSWE.nanoFramework.WebServer/CCSWE.nanoFramework.WebServer.nuspec
@@ -17,19 +17,21 @@
     <copyright>Copyright (c) Cory Charlton</copyright>
     <tags>nanoFramework C# csharp netmf netnf ccswe web server http</tags>
     <dependencies>
-      <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
-      <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
-      <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
-      <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-      <dependency id="nanoFramework.Json" version="2.2.203" />
-      <dependency id="nanoFramework.Logging" version="1.1.161" />
-      <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
-      <dependency id="nanoFramework.System.Collections" version="1.5.67" />
-      <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
-      <dependency id="nanoFramework.System.Net" version="1.11.50" />
-      <dependency id="nanoFramework.System.Net.Http" version="1.5.203" />
-      <dependency id="nanoFramework.System.Text" version="1.3.42" />
-      <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      <group targetFramework=".NETnanoFramework1.0">
+        <dependency id="CCSWE.nanoFramework.Core" version="$version$" />
+        <dependency id="CCSWE.nanoFramework.Threading" version="$version$" />
+        <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
+        <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
+        <dependency id="nanoFramework.Json" version="2.2.203" />
+        <dependency id="nanoFramework.Logging" version="1.1.161" />
+        <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
+        <dependency id="nanoFramework.System.Collections" version="1.5.67" />
+        <dependency id="nanoFramework.System.IO.Streams" version="1.1.96" />
+        <dependency id="nanoFramework.System.Net" version="1.11.50" />
+        <dependency id="nanoFramework.System.Net.Http" version="1.5.203" />
+        <dependency id="nanoFramework.System.Text" version="1.3.42" />
+        <dependency id="nanoFramework.System.Threading" version="1.1.52" />
+      </group>
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
## Summary

- Cache `_fullyQualifiedHostname` and `_fullyQualifiedHostnameLower` as class fields, updated via new `SetHostname`/`SetIPAddress` helpers whenever the hostname changes
- Pre-compute `fullyQualifiedInstanceNames[]` and `fullyQualifiedInstanceNameLowers[]` arrays once per message before the question loop, eliminating repeated `GetFullyQualifiedInstanceName` + `ToLower` calls per query type
- Cache `ServiceTypeLower` on `MdnsServiceRegistration` (computed once at construction) and use it in PTR loops instead of calling `ToLower` per iteration
- Add `MdnsServerOptions.IPAddress` so the IP can be provided at construction alongside hostname
- Add `MdnsResponse.IsEmpty()` and use it to decide whether to respond instead of a separate `shouldRespond` flag
- Make `ServiceTypeLower` and `GetFullyQualifiedInstanceName` internal

## Test plan

- [x] Build solution in Release configuration
- [x] Smoke test with a real device or mDNS query tool (`dns-sd`, Avahi) to verify A, PTR, SRV, and TXT responses are correct
- [x] Verify announcement fires correctly on `Start()` and `Announce()`