### PR TITLE
Bump nanoFramework.Iot.Device.MulticastDns to 1.0.272

### DIFF
--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/Samples.CCSWE.nanoFramework.MdnsServer.nfproj
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/Samples.CCSWE.nanoFramework.MdnsServer.nfproj
@@ -38,6 +38,9 @@
     <ProjectReference Include="..\..\src\CCSWE.nanoFramework.WebServer\CCSWE.nanoFramework.WebServer.nfproj" />
   </ItemGroup>
   <ItemGroup>
+    <Reference Include="Iot.Device.MulticastDns, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.MulticastDns.1.0.272\lib\Iot.Device.MulticastDns.dll</HintPath>
+    </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>
     </Reference>
@@ -80,6 +83,9 @@
     <Reference Include="System.Threading, Version=1.1.52.34401, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.System.Threading.1.1.52\lib\System.Threading.dll</HintPath>
     </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="packages.lock.json" />
   </ItemGroup>
   <Import Project="$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets" Condition="Exists('$(NanoFrameworkProjectSystemPath)NFProjectSystem.CSharp.targets')" />
   <ProjectExtensions>

--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.config
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.config
@@ -3,7 +3,7 @@
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hosting" version="2.0.11" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.260" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.272" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />

--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.lock.json
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "nanoFramework.Iot.Device.MulticastDns": {
         "type": "Direct",
-        "requested": "[1.0.260, 1.0.260]",
-        "resolved": "1.0.260",
-        "contentHash": "aFdedzEzR4RCHToBlf7q88+WXZWRSXFEnUE7ozihW1DoO90c3DSsy4M619cUgIkORaQg/RhbMS359Ey+9Fybmg=="
+        "requested": "[1.0.272, 1.0.272]",
+        "resolved": "1.0.272",
+        "contentHash": "JO/BCEAH3Jbn3ieQwLOyggNKvFhxL1gz/9KAZKdyHa4JWu580k8fb6Iz5MUH7evhPaE1mdHjeN+6FL9N4Q/PVg=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",

--- a/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nfproj
+++ b/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nfproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.MulticastDns, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.MulticastDns.1.0.260\lib\Iot.Device.MulticastDns.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.MulticastDns.1.0.272\lib\Iot.Device.MulticastDns.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>

--- a/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nuspec
+++ b/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nuspec
@@ -20,7 +20,7 @@
       <group targetFramework=".NETnanoFramework1.0">
         <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
         <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-        <dependency id="nanoFramework.Iot.Device.MulticastDns" version="1.0.260" />
+        <dependency id="nanoFramework.Iot.Device.MulticastDns" version="1.0.272" />
         <dependency id="nanoFramework.Logging" version="1.1.161" />
         <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
         <dependency id="nanoFramework.System.Buffers.Binary.BinaryPrimitives" version="1.2.862" />

--- a/src/CCSWE.nanoFramework.MdnsServer/packages.config
+++ b/src/CCSWE.nanoFramework.MdnsServer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.260" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.272" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Buffers.Binary.BinaryPrimitives" version="1.2.862" targetFramework="netnano1.0" />

--- a/src/CCSWE.nanoFramework.MdnsServer/packages.lock.json
+++ b/src/CCSWE.nanoFramework.MdnsServer/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "nanoFramework.Iot.Device.MulticastDns": {
         "type": "Direct",
-        "requested": "[1.0.260, 1.0.260]",
-        "resolved": "1.0.260",
-        "contentHash": "aFdedzEzR4RCHToBlf7q88+WXZWRSXFEnUE7ozihW1DoO90c3DSsy4M619cUgIkORaQg/RhbMS359Ey+9Fybmg=="
+        "requested": "[1.0.272, 1.0.272]",
+        "resolved": "1.0.272",
+        "contentHash": "JO/BCEAH3Jbn3ieQwLOyggNKvFhxL1gz/9KAZKdyHa4JWu580k8fb6Iz5MUH7evhPaE1mdHjeN+6FL9N4Q/PVg=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",


### PR DESCRIPTION
## Summary
- Bumps `nanoFramework.Iot.Device.MulticastDns` from 1.0.260 to 1.0.272 across `src/CCSWE.nanoFramework.MdnsServer` (and its sample), keeping the nuspec dep in sync.
- Fills in Version/Culture/PublicKeyToken on the `Iot.Device.MulticastDns` `<Reference>` Includes in both projects so they match the rest of the codebase's complete-identity convention.

## Test plan
- [x] `msbuild CCSWE.nanoFramework.sln /p:Configuration=Release` clean
- [x] vstest across all UnitTest assemblies: 151 passed / 3 skipped / 0 failed (same as previous master)
- [x] Local dep-sync validator: 0 errors / 6 (benign transitive-only) warnings
- [ ] CI green