### PR TITLE
Bump nanoFramework.Hosting from 2.0.11 to 2.0.15

### DIFF
--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/Samples.CCSWE.nanoFramework.MdnsServer.nfproj
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/Samples.CCSWE.nanoFramework.MdnsServer.nfproj
@@ -47,8 +47,8 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Hosting, Version=2.0.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.11\lib\nanoFramework.Hosting.dll</HintPath>
+    <Reference Include="nanoFramework.Hosting, Version=2.0.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.15\lib\nanoFramework.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Logging, Version=1.1.161.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.161\lib\nanoFramework.Logging.dll</HintPath>

--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.config
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Hosting" version="2.0.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hosting" version="2.0.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.283" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />

--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.lock.json
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "nanoFramework.Hosting": {
         "type": "Direct",
-        "requested": "[2.0.11, 2.0.11]",
-        "resolved": "2.0.11",
-        "contentHash": "gs6c2fVEnAy5vskaZG2ZUIeGnxPX58W28+jBCC6aSKfEEwg3Jg4PIFdgFpRnemiqTpllqGZ5jPyBP0oyhg5Zfw=="
+        "requested": "[2.0.15, 2.0.15]",
+        "resolved": "2.0.15",
+        "contentHash": "dIBAQpCR4rH5daviYWRhRFcgm11l8GpVPIOrSYUDRDF1p498t1siiIPSMKqnfc0rRcBw9UEpn/QPmRF9l9jWYA=="
       },
       "nanoFramework.Iot.Device.MulticastDns": {
         "type": "Direct",

--- a/samples/Samples.CCSWE.nanoFramework.Networking/Samples.CCSWE.nanoFramework.Networking.nfproj
+++ b/samples/Samples.CCSWE.nanoFramework.Networking/Samples.CCSWE.nanoFramework.Networking.nfproj
@@ -41,8 +41,8 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Hosting, Version=2.0.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.11\lib\nanoFramework.Hosting.dll</HintPath>
+    <Reference Include="nanoFramework.Hosting, Version=2.0.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.15\lib\nanoFramework.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Logging, Version=1.1.161.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.161\lib\nanoFramework.Logging.dll</HintPath>

--- a/samples/Samples.CCSWE.nanoFramework.Networking/packages.config
+++ b/samples/Samples.CCSWE.nanoFramework.Networking/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Hosting" version="2.0.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hosting" version="2.0.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />

--- a/samples/Samples.CCSWE.nanoFramework.Networking/packages.lock.json
+++ b/samples/Samples.CCSWE.nanoFramework.Networking/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "nanoFramework.Hosting": {
         "type": "Direct",
-        "requested": "[2.0.11, 2.0.11]",
-        "resolved": "2.0.11",
-        "contentHash": "gs6c2fVEnAy5vskaZG2ZUIeGnxPX58W28+jBCC6aSKfEEwg3Jg4PIFdgFpRnemiqTpllqGZ5jPyBP0oyhg5Zfw=="
+        "requested": "[2.0.15, 2.0.15]",
+        "resolved": "2.0.15",
+        "contentHash": "dIBAQpCR4rH5daviYWRhRFcgm11l8GpVPIOrSYUDRDF1p498t1siiIPSMKqnfc0rRcBw9UEpn/QPmRF9l9jWYA=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",

--- a/samples/Samples.CCSWE.nanoFramework.WebServer/Samples.CCSWE.nanoFramework.WebServer.nfproj
+++ b/samples/Samples.CCSWE.nanoFramework.WebServer/Samples.CCSWE.nanoFramework.WebServer.nfproj
@@ -47,8 +47,8 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Hosting, Version=2.0.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.11\lib\nanoFramework.Hosting.dll</HintPath>
+    <Reference Include="nanoFramework.Hosting, Version=2.0.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.15\lib\nanoFramework.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Logging, Version=1.1.161.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.161\lib\nanoFramework.Logging.dll</HintPath>

--- a/samples/Samples.CCSWE.nanoFramework.WebServer/packages.config
+++ b/samples/Samples.CCSWE.nanoFramework.WebServer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Hosting" version="2.0.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hosting" version="2.0.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />

--- a/samples/Samples.CCSWE.nanoFramework.WebServer/packages.lock.json
+++ b/samples/Samples.CCSWE.nanoFramework.WebServer/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "nanoFramework.Hosting": {
         "type": "Direct",
-        "requested": "[2.0.11, 2.0.11]",
-        "resolved": "2.0.11",
-        "contentHash": "gs6c2fVEnAy5vskaZG2ZUIeGnxPX58W28+jBCC6aSKfEEwg3Jg4PIFdgFpRnemiqTpllqGZ5jPyBP0oyhg5Zfw=="
+        "requested": "[2.0.15, 2.0.15]",
+        "resolved": "2.0.15",
+        "contentHash": "dIBAQpCR4rH5daviYWRhRFcgm11l8GpVPIOrSYUDRDF1p498t1siiIPSMKqnfc0rRcBw9UEpn/QPmRF9l9jWYA=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",

--- a/src/CCSWE.nanoFramework.Hosting/CCSWE.nanoFramework.Hosting.nfproj
+++ b/src/CCSWE.nanoFramework.Hosting/CCSWE.nanoFramework.Hosting.nfproj
@@ -37,8 +37,8 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Hosting, Version=2.0.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.11\lib\nanoFramework.Hosting.dll</HintPath>
+    <Reference Include="nanoFramework.Hosting, Version=2.0.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.15\lib\nanoFramework.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Logging, Version=1.1.161.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.161\lib\nanoFramework.Logging.dll</HintPath>

--- a/src/CCSWE.nanoFramework.Hosting/CCSWE.nanoFramework.Hosting.nuspec
+++ b/src/CCSWE.nanoFramework.Hosting/CCSWE.nanoFramework.Hosting.nuspec
@@ -22,7 +22,7 @@
         <dependency id="CCSWE.nanoFramework.Logging" version="$version$" />
         <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
         <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-        <dependency id="nanoFramework.Hosting" version="2.0.11" />
+        <dependency id="nanoFramework.Hosting" version="2.0.15" />
         <dependency id="nanoFramework.Logging" version="1.1.161" />
         <dependency id="nanoFramework.System.Collections" version="1.5.75" />
         <dependency id="nanoFramework.System.Text" version="1.3.42" />

--- a/src/CCSWE.nanoFramework.Hosting/packages.config
+++ b/src/CCSWE.nanoFramework.Hosting/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Hosting" version="2.0.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hosting" version="2.0.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.75" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Text" version="1.3.42" targetFramework="netnano1.0" />

--- a/src/CCSWE.nanoFramework.Hosting/packages.lock.json
+++ b/src/CCSWE.nanoFramework.Hosting/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "nanoFramework.Hosting": {
         "type": "Direct",
-        "requested": "[2.0.11, 2.0.11]",
-        "resolved": "2.0.11",
-        "contentHash": "gs6c2fVEnAy5vskaZG2ZUIeGnxPX58W28+jBCC6aSKfEEwg3Jg4PIFdgFpRnemiqTpllqGZ5jPyBP0oyhg5Zfw=="
+        "requested": "[2.0.15, 2.0.15]",
+        "resolved": "2.0.15",
+        "contentHash": "dIBAQpCR4rH5daviYWRhRFcgm11l8GpVPIOrSYUDRDF1p498t1siiIPSMKqnfc0rRcBw9UEpn/QPmRF9l9jWYA=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",

--- a/test/UnitTests.CCSWE.nanoFramework.Hosting/UnitTests.CCSWE.nanoFramework.Hosting.nfproj
+++ b/test/UnitTests.CCSWE.nanoFramework.Hosting/UnitTests.CCSWE.nanoFramework.Hosting.nfproj
@@ -48,8 +48,8 @@
     <Reference Include="nanoFramework.DependencyInjection, Version=1.1.32.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.DependencyInjection.1.1.32\lib\nanoFramework.DependencyInjection.dll</HintPath>
     </Reference>
-    <Reference Include="nanoFramework.Hosting, Version=2.0.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.11\lib\nanoFramework.Hosting.dll</HintPath>
+    <Reference Include="nanoFramework.Hosting, Version=2.0.15.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
+      <HintPath>..\..\packages\nanoFramework.Hosting.2.0.15\lib\nanoFramework.Hosting.dll</HintPath>
     </Reference>
     <Reference Include="nanoFramework.Logging, Version=1.1.161.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.Logging.1.1.161\lib\nanoFramework.Logging.dll</HintPath>

--- a/test/UnitTests.CCSWE.nanoFramework.Hosting/packages.config
+++ b/test/UnitTests.CCSWE.nanoFramework.Hosting/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Hosting" version="2.0.11" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Hosting" version="2.0.15" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Collections" version="1.5.75" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Threading" version="1.1.52" targetFramework="netnano1.0" />

--- a/test/UnitTests.CCSWE.nanoFramework.Hosting/packages.lock.json
+++ b/test/UnitTests.CCSWE.nanoFramework.Hosting/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "nanoFramework.Hosting": {
         "type": "Direct",
-        "requested": "[2.0.11, 2.0.11]",
-        "resolved": "2.0.11",
-        "contentHash": "gs6c2fVEnAy5vskaZG2ZUIeGnxPX58W28+jBCC6aSKfEEwg3Jg4PIFdgFpRnemiqTpllqGZ5jPyBP0oyhg5Zfw=="
+        "requested": "[2.0.15, 2.0.15]",
+        "resolved": "2.0.15",
+        "contentHash": "dIBAQpCR4rH5daviYWRhRFcgm11l8GpVPIOrSYUDRDF1p498t1siiIPSMKqnfc0rRcBw9UEpn/QPmRF9l9jWYA=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",


### PR DESCRIPTION
Updates nanoFramework.Hosting from 2.0.11 to 2.0.15 across the Hosting library, its unit tests, and the MdnsServer/Networking/WebServer samples. Includes the matching `.nuspec` dependency bump for CCSWE.nanoFramework.Hosting.