### PR TITLE
Bump nanoFramework.Iot.Device.MulticastDns to 1.0.286 and Ws28xx.Esp32 to 1.2.994

### DIFF
--- a/bench/Benchmarks.CCSWE.nanoFramework.NeoPixel/Benchmarks.CCSWE.nanoFramework.NeoPixel.nfproj
+++ b/bench/Benchmarks.CCSWE.nanoFramework.NeoPixel/Benchmarks.CCSWE.nanoFramework.NeoPixel.nfproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.Ws28xx.Esp32, Version=1.2.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.Ws28xx.Esp32.1.2.991\lib\Iot.Device.Ws28xx.Esp32.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.Ws28xx.Esp32.1.2.994\lib\Iot.Device.Ws28xx.Esp32.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>

--- a/bench/Benchmarks.CCSWE.nanoFramework.NeoPixel/packages.config
+++ b/bench/Benchmarks.CCSWE.nanoFramework.NeoPixel/packages.config
@@ -4,7 +4,7 @@
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.Graphics.Core" version="1.2.52" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hardware.Esp32.Rmt" version="2.0.35" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.Ws28xx.Esp32" version="1.2.991" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.Ws28xx.Esp32" version="1.2.994" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />

--- a/bench/Benchmarks.CCSWE.nanoFramework.NeoPixel/packages.lock.json
+++ b/bench/Benchmarks.CCSWE.nanoFramework.NeoPixel/packages.lock.json
@@ -28,9 +28,9 @@
       },
       "nanoFramework.Iot.Device.Ws28xx.Esp32": {
         "type": "Direct",
-        "requested": "[1.2.991, 1.2.991]",
-        "resolved": "1.2.991",
-        "contentHash": "HKtVOqDbqIZsgwOEu6nePiIj65t8XNmkKe5/xX+xiyAJay2GvTiFoK7Bufj7xWC1x0BzPvZC1xBh4LA/geRrnQ=="
+        "requested": "[1.2.994, 1.2.994]",
+        "resolved": "1.2.994",
+        "contentHash": "n7Nf29o6urRm+OgUr27NmUifH6C5yWpgyTub/NRi51hCbHKYHNfD1O34gKThSmjhGShs057DrSCd3wDSTFHLhg=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",

--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/Samples.CCSWE.nanoFramework.MdnsServer.nfproj
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/Samples.CCSWE.nanoFramework.MdnsServer.nfproj
@@ -39,7 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.MulticastDns, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.MulticastDns.1.0.283\lib\Iot.Device.MulticastDns.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.MulticastDns.1.0.286\lib\Iot.Device.MulticastDns.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>

--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.config
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.config
@@ -3,7 +3,7 @@
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Hosting" version="2.0.15" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.283" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.286" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Native" version="1.7.11" targetFramework="netnano1.0" />

--- a/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.lock.json
+++ b/samples/Samples.CCSWE.nanoFramework.MdnsServer/packages.lock.json
@@ -22,9 +22,9 @@
       },
       "nanoFramework.Iot.Device.MulticastDns": {
         "type": "Direct",
-        "requested": "[1.0.283, 1.0.283]",
-        "resolved": "1.0.283",
-        "contentHash": "R2/XGRbPVuuEQiQ1M2wdVsVRLMw9JgKrGG06uYe6UGvy8QMUksQnScfvIpC/oXmAMNvAD/2B1ZObTi9wQz/gow=="
+        "requested": "[1.0.286, 1.0.286]",
+        "resolved": "1.0.286",
+        "contentHash": "a7R+YamhwdiezlGCxILKwJCusBmLNfB3yrbzq2SEUzxdpIHUai59H7pG1n8FkRKwd98gAx097qZN6pMx1C+dCA=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",

--- a/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nfproj
+++ b/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nfproj
@@ -38,7 +38,7 @@
   </ItemGroup>
   <ItemGroup>
     <Reference Include="Iot.Device.MulticastDns, Version=1.0.0.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
-      <HintPath>..\..\packages\nanoFramework.Iot.Device.MulticastDns.1.0.283\lib\Iot.Device.MulticastDns.dll</HintPath>
+      <HintPath>..\..\packages\nanoFramework.Iot.Device.MulticastDns.1.0.286\lib\Iot.Device.MulticastDns.dll</HintPath>
     </Reference>
     <Reference Include="mscorlib, Version=1.17.11.0, Culture=neutral, PublicKeyToken=c07d481e9758c731">
       <HintPath>..\..\packages\nanoFramework.CoreLibrary.1.17.11\lib\mscorlib.dll</HintPath>

--- a/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nuspec
+++ b/src/CCSWE.nanoFramework.MdnsServer/CCSWE.nanoFramework.MdnsServer.nuspec
@@ -20,7 +20,7 @@
       <group targetFramework=".NETnanoFramework1.0">
         <dependency id="nanoFramework.CoreLibrary" version="1.17.11" />
         <dependency id="nanoFramework.DependencyInjection" version="1.1.32" />
-        <dependency id="nanoFramework.Iot.Device.MulticastDns" version="1.0.283" />
+        <dependency id="nanoFramework.Iot.Device.MulticastDns" version="1.0.286" />
         <dependency id="nanoFramework.Logging" version="1.1.161" />
         <dependency id="nanoFramework.Runtime.Events" version="1.11.32" />
         <dependency id="nanoFramework.System.Buffers.Binary.BinaryPrimitives" version="1.2.862" />

--- a/src/CCSWE.nanoFramework.MdnsServer/packages.config
+++ b/src/CCSWE.nanoFramework.MdnsServer/packages.config
@@ -2,7 +2,7 @@
 <packages>
   <package id="nanoFramework.CoreLibrary" version="1.17.11" targetFramework="netnano1.0" />
   <package id="nanoFramework.DependencyInjection" version="1.1.32" targetFramework="netnano1.0" />
-  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.283" targetFramework="netnano1.0" />
+  <package id="nanoFramework.Iot.Device.MulticastDns" version="1.0.286" targetFramework="netnano1.0" />
   <package id="nanoFramework.Logging" version="1.1.161" targetFramework="netnano1.0" />
   <package id="nanoFramework.Runtime.Events" version="1.11.32" targetFramework="netnano1.0" />
   <package id="nanoFramework.System.Buffers.Binary.BinaryPrimitives" version="1.2.862" targetFramework="netnano1.0" />

--- a/src/CCSWE.nanoFramework.MdnsServer/packages.lock.json
+++ b/src/CCSWE.nanoFramework.MdnsServer/packages.lock.json
@@ -16,9 +16,9 @@
       },
       "nanoFramework.Iot.Device.MulticastDns": {
         "type": "Direct",
-        "requested": "[1.0.283, 1.0.283]",
-        "resolved": "1.0.283",
-        "contentHash": "R2/XGRbPVuuEQiQ1M2wdVsVRLMw9JgKrGG06uYe6UGvy8QMUksQnScfvIpC/oXmAMNvAD/2B1ZObTi9wQz/gow=="
+        "requested": "[1.0.286, 1.0.286]",
+        "resolved": "1.0.286",
+        "contentHash": "a7R+YamhwdiezlGCxILKwJCusBmLNfB3yrbzq2SEUzxdpIHUai59H7pG1n8FkRKwd98gAx097qZN6pMx1C+dCA=="
       },
       "nanoFramework.Logging": {
         "type": "Direct",


### PR DESCRIPTION
Updates nanoFramework.Iot.Device.MulticastDns from 1.0.283 to 1.0.286 (MdnsServer library + sample, plus the matching `.nuspec` dependency) and nanoFramework.Iot.Device.Ws28xx.Esp32 from 1.2.991 to 1.2.994 (NeoPixel benchmark).